### PR TITLE
nwmatcher: Avoid css3-compat false negative for :target in Chrome

### DIFF
--- a/test/css3-compat/css3-compat.js
+++ b/test/css3-compat/css3-compat.js
@@ -13,9 +13,9 @@ var CDN = 'http://ajax.googleapis.com/ajax/libs/',
 engines = {
   'querySelectorAll':   [ 'document.querySelectorAll(s)',    '' ],
 
-  'nwmatcher-1.2.3':    [ 'NW.Dom.select(s)',                '../../src/nwmatcher.js' ],
-  'base2-2.0alpha1':    [ 'base2.dom.querySelectorAll(c,s)', 'lib/base2+dom.js' ],
+  'nwmatcher-1.2.4beta':    [ 'NW.Dom.select(s)',                '../../src/nwmatcher.js' ],
 
+//  'base2-2.0alpha1':    [ 'base2.dom.querySelectorAll(c,s)', 'lib/base2+dom.js' ],
 //  'prototype-1.6.1':    [ '$$(s)',                           CDN + 'prototype/1.6.1.0/prototype.js' ],
 //  'dojo-1.4.1':         [ 'dojo.query(s)',                   CDN + 'dojo/1.4.1/dojo/dojo.xd.js' ],
 //  'mootools-1.2.4':     [ '$$(s)',                           CDN + 'mootools/1.2.4/mootools.js' ],
@@ -248,7 +248,7 @@ engines = {
         // no need to load a framework
         engine = 'querySelectorAll';
         location.hash = '#target';
-        startTest();
+        setTimeout(startTest, 10);
       }
     };
 


### PR DESCRIPTION
nwmatcher: Avoid css3-compat false negative for :target in Chrome. [jddalton]
