### PR TITLE
nwmatcher: Avoid QSA and other fancy API when working with XMLish docs for better compat. [jddalton]

### DIFF
--- a/src/nwmatcher.js
+++ b/src/nwmatcher.js
@@ -1373,7 +1373,7 @@
       }
 
       // use matchesSelector API if available
-      if (USE_QSAPI && element[NATIVE_MATCHES_SELECTOR] &&
+      if (USE_QSAPI && !XML_DOCUMENT && element[NATIVE_MATCHES_SELECTOR] &&
         !(BUGGY_QSAPI_QUIRKS && RE_CLASS.test(selector)) &&
         !(BUGGY_PSEUDOS && RE_PSEUDOS.test(selector)) &&
         !RE_BUGGY_QSAPI.test(selector)) {
@@ -1447,7 +1447,7 @@
           concatCall([ ], elements, callback) : elements;
       }
 
-      if (USE_QSAPI &&
+      if (USE_QSAPI && !XML_DOCUMENT &&
         !(BUGGY_QSAPI_QUIRKS && RE_CLASS.test(selector)) &&
         !RE_BUGGY_QSAPI.test(selector) &&
         QSA_NODE_TYPES[from.nodeType]) {


### PR DESCRIPTION
Here is a failing test case for XML with QSA: http://dl.dropbox.com/u/513327/chrome_xml/index.html
