### PR TITLE
added .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,4 @@ test/ender/.gitignore
 .gitattributes
 .gitignore
 Makefile
+node_modules/


### PR DESCRIPTION
This should cut the NPM package down from ~5M to ~31K

I have trouble with the `make` process on Linux (I think it's a 64-bit incompatibility thing), so the _dist/_ directory doesn't have the full thing for me so when I publish it's not quite complete. However, since the _package.json_ points to the _src/_ directory, if anyone is using NWMatcher in Ender then the source is picked up from there, not _dist/_.
