### PR TITLE
Use document as root if documentElement is not defined

### DIFF
--- a/src/nwmatcher.js
+++ b/src/nwmatcher.js
@@ -45,7 +45,7 @@
 
   // processing context & root element
   doc = global.document,
-  root = doc.documentElement,
+  root = doc.documentElement || doc,
 
   // save utility methods references
   slice = [ ].slice,


### PR DESCRIPTION
`nwmatcher` crashes in `jsdom` if `doc.documentElement` is not defined, for example when there is no root `HTML` element (see tmpvar/jsdom#555).

I'm unsure whether this is a bug in `nwmatcher` or `jsdom`, but this fix eliminates it.
