### PR TITLE
Fix

### DIFF
--- a/src/nwmatcher-noqsa.js
+++ b/src/nwmatcher-noqsa.js
@@ -34,7 +34,7 @@
   var Dom = exports,
 
   doc = global.document,
-  root = doc.documentElement,
+  root = ((typeof doc == 'object')?doc.documentElement:{}),
 
   isSingleMatch,
   isSingleSelect,


### PR DESCRIPTION
I was using https://github.com/rsdoiel/extractor-js and was getting this error:

/Users/mcollins/projects/wolf/node_modules/extractor/node_modules/jsdom/node_modules/nwmatcher/src/nwmatcher-noqsa.js:233
  contains = 'compareDocumentPosition' in root ?
                                          ^
TypeError: Cannot use 'in' operator to search for 'compareDocumentPosition' in null
    at /Users/mcollins/projects/wolf/node_modules/extractor/node_modules/jsdom/node_modules/nwmatcher/src/nwmatcher-noqsa.js:233:43

Found that root was not always defined in nwatcher so put in a fix to stop this. Worked for my usage, not sure if there is a more elegant fix you would like to try!
