### PR TITLE
Fixes https://github.com/dperini/nwmatcher/issues/79

### DIFF
--- a/src/nwmatcher-base.js
+++ b/src/nwmatcher-base.js
@@ -294,6 +294,24 @@
       return _byId(id, from);
     },
 
+  // elements by tag (raw)
+  // @return array
+  byTagRaw =
+    function(tag, from) {
+      var any = tag == '*', element = from, elements = new global.Array(), next = element.firstChild;
+      any || (tag = tag.toUpperCase());
+      while ((element = next)) {
+        if (element.tagName > '@' && (any || element.tagName.toUpperCase() == tag)) {
+          elements[elements.length] = element;
+        }
+        if ((next = element.firstChild || element.nextSibling)) continue;
+        while (!next && (element = element.parentNode) && element !== from) {
+          next = element.nextSibling;
+        }
+      }
+      return elements;
+    },
+
   getAttribute =
     function(node, attribute) {
       attribute = attribute.toLowerCase();
@@ -550,7 +568,7 @@
 
       if (from.nodeType == 11) {
 
-        elements = from.childNodes;
+        elements = byTagRaw('*', from);
 
       } else if (isSingleSelect) {
 

--- a/src/nwmatcher-noqsa.js
+++ b/src/nwmatcher-noqsa.js
@@ -245,6 +245,24 @@
       if (lastContext !== from) { switchContext(from); }
       return _byId(id, from);
     },
+    
+  // elements by tag (raw)
+  // @return array
+  byTagRaw =
+    function(tag, from) {
+      var any = tag == '*', element = from, elements = new global.Array(), next = element.firstChild;
+      any || (tag = tag.toUpperCase());
+      while ((element = next)) {
+        if (element.tagName > '@' && (any || element.tagName.toUpperCase() == tag)) {
+          elements[elements.length] = element;
+        }
+        if ((next = element.firstChild || element.nextSibling)) continue;
+        while (!next && (element = element.parentNode) && element !== from) {
+          next = element.nextSibling;
+        }
+      }
+      return elements;
+    },
 
   contains = 'compareDocumentPosition' in root ?
     function(container, element) {
@@ -722,7 +740,7 @@
 
       if (from.nodeType == 11) {
 
-        elements = from.childNodes;
+        elements = byTagRaw('*', from);
 
       } else if (isSingleSelect) {
 

--- a/src/nwmatcher.js
+++ b/src/nwmatcher.js
@@ -1417,7 +1417,7 @@
       // commas separators are treated sequentially to maintain order
       if (from.nodeType == 11) {
 
-        elements = from.childNodes;
+        elements = byTagRaw('*', from);
 
       } else if (!XML_DOCUMENT && isSingleSelect) {
 

--- a/test/ender/ender.js
+++ b/test/ender/ender.js
@@ -1506,7 +1506,7 @@
         // commas separators are treated sequentially to maintain order
         if (from.nodeType == 11) {
   
-          elements = from.childNodes;
+          elements = byTagRaw('*', from);
   
         } else if (!XML_DOCUMENT && isSingleSelect) {
   


### PR DESCRIPTION
Selectors on DocumentFragments (node type 11) are now able to match the children of its children.
This is consistent with DocumentFragment.querySelector() in firefox and chrome.
