### PR TITLE
Tolerate a missing document.documentElement

### DIFF
--- a/src/nwmatcher-noqsa.js
+++ b/src/nwmatcher-noqsa.js
@@ -264,10 +264,10 @@
       return elements;
     },
 
-  contains = 'compareDocumentPosition' in root ?
+  contains = root && 'compareDocumentPosition' in root ?
     function(container, element) {
       return (container.compareDocumentPosition(element) & 16) == 16;
-    } : 'contains' in root ?
+    } : root && 'contains' in root ?
     function(container, element) {
       return element.nodeType == 1 && container.contains(element);
     } :
@@ -292,7 +292,7 @@
           ((node = node.getAttributeNode(attribute)) && node.value) || '');
     },
 
-  hasAttribute = root.hasAttribute ?
+  hasAttribute = root && root.hasAttribute ?
     function(node, attribute) {
       return node.hasAttribute(attribute);
     } :

--- a/src/nwmatcher.js
+++ b/src/nwmatcher.js
@@ -244,7 +244,7 @@
 
   // supports the new traversal API
   NATIVE_TRAVERSAL_API =
-    'nextElementSibling' in root && 'previousElementSibling' in root,
+    root && 'nextElementSibling' in root && 'previousElementSibling' in root,
 
   // BUGGY_XXXXX true if method is feature tested and has known bugs
   // detect buggy gEBID
@@ -721,10 +721,10 @@
 
   // check element is descendant of container
   // @return boolean
-  contains = 'compareDocumentPosition' in root ?
+  contains = root && 'compareDocumentPosition' in root ?
     function(container, element) {
       return (container.compareDocumentPosition(element) & 16) == 16;
-    } : 'contains' in root ?
+    } : root && 'contains' in root ?
     function(container, element) {
       return container !== element && container.contains(element);
     } :


### PR DESCRIPTION
There's a problem with the way nwmatcher is integrated into jsdom that makes `querySelectorAll` throw an error when the document does not have an `<html>` element and thus no `document.documentElement`. It turned out that it was easy to fix in nwmatcher, so I thought I'd try that first.

If you consider this to be too much of a fringe case, I'll look into fixing it in jsdom instead. Maybe it'd be sufficient to pass a bogus object as `document.documentElement`, but I have a feeling that it'd get ugly.

See tmpvar/jsdom#330, tmpvar/jsdom#555
