### PR TITLE
Support escaped numbers in CSS identifiers

### DIFF
--- a/src/nwmatcher-noqsa.js
+++ b/src/nwmatcher-noqsa.js
@@ -67,6 +67,8 @@
   lastPartsMatch,
   lastPartsSelect,
 
+  prefixes = '[#.:]?',
+
   operators = '([~*^$|!]?={1})',
   combinators = '[\\s]|[>+~](?=[^>+~])',
   pseudoparms = '(?:[-+]?\\d*n)?[-+]?\\d*',
@@ -74,8 +76,8 @@
   quotedvalue = '"[^"\\\\]*(?:\\\\.[^"\\\\]*)*"' + "|'[^'\\\\]*(?:\\\\.[^'\\\\]*)*'",
   skipgroup = '\\[.*\\]|\\(.*\\)|\\{.*\\}',
 
-  encoding = '(?:[-\\w]|[^\\x00-\\xa0]|\\\\.)',
-  identifier = '(?:-?[_a-zA-Z]{1}[-\\w]*|[^\\x00-\\xa0]+|\\\\.+)+',
+  encoding = '(?:\\\\\\d{1,5} |[-\\w]|[^\\x00-\\xa0]|\\\\.)',
+  identifier = '(?:-?[_a-zA-Z]{1}[-\\w]*|[^\\x00-\\xa0]+|\\\\.+|\\\\\\d{1,5} )+',
 
   attrcheck = '(' + quotedvalue + '|' + identifier + ')',
   attributes = '\\s*(' + encoding + '*:?' + encoding + '+)\\s*(?:' + operators + '\\s*' + attrcheck + ')?\\s*',
@@ -122,6 +124,7 @@
   reSplitToken = global.RegExp('(' +
     '\\[' + attributes + '\\]|' +
     '\\(' + pseudoclass + '\\)|' +
+    prefixes + identifier + '|' +
     '\\\\.|[^\\s>+~])+', 'g'),
 
   reOptimizeSelector = global.RegExp(identifier + '|^$'),
@@ -250,6 +253,29 @@
       });
     },
 
+  unescapeIdentifier =
+    function(str) {
+      return str.replace(/\\([0-9a-fA-F]{1,6}\x20?|.)|([\x22\x27])/g, function(substring, p1, p2) {
+        var codePoint, highHex, highSurrogate, lowHex, lowSurrogate;
+
+        if (p2) {
+          return p2;
+        }
+
+        if (/^[0-9a-fA-F]/.test(p1)) {
+          codePoint = parseInt(p1, 16);
+          return String.fromCharCode(codePoint);
+        }
+
+        if (/^[\\\x22\x27]/.test(p1)) {
+          return substring;
+        }
+
+        return p1;
+      });
+    },
+
+
   byIdRaw =
     function(id, elements) {
       var i = -1, element = null;
@@ -263,13 +289,13 @@
 
   _byId = !('fileSize' in doc) ?
     function(id, from) {
-      id = id.replace(/\\([^\\]{1})/g, '$1');
+      id = unescapeIdentifier(id);
       return from.getElementById && from.getElementById(id) ||
         byIdRaw(id, from.getElementsByTagName('*'));
     } :
     function(id, from) {
       var element = null;
-      id = id.replace(/\\([^\\]{1})/g, '$1');
+      id = unescapeIdentifier(id);
       if (XML_DOCUMENT || from.nodeType != 9) {
         return byIdRaw(id, from.getElementsByTagName('*'));
       }
@@ -471,7 +497,7 @@
           source = 'if(' + (XML_DOCUMENT ?
             's.getAttribute(e,"id")' :
             '(e.submit?s.getAttribute(e,"id"):e.id)') +
-            '=="' + match[1] + '"' +
+            '=="' + convertEscapes(match[1]) + '"' +
             '){' + source + '}';
         }
 
@@ -487,7 +513,7 @@
             'e.getAttribute("class")' : 'e.className') +
             ')&&n.length&&(" "+' + (QUIRKS_MODE ? 'n.toLowerCase()' : 'n') +
             '.replace(/\\s+/g," ")+" ").indexOf(" ' +
-            (QUIRKS_MODE ? match[1].toLowerCase() : match[1]) + ' ")>-1' +
+            convertEscapes(QUIRKS_MODE ? match[1].toLowerCase() : match[1]) + ' ")>-1' +
             '){' + source + '}';
         }
 
@@ -811,7 +837,7 @@
         }
 
         else if (!XML_DOCUMENT && GEBCN && (parts = lastSlice.match(Optimize.CLASS)) && (token = parts[1])) {
-          if ((elements = from.getElementsByClassName(token.replace(/\\([^\\]{1})/g, '$1'))).length === 0) { return [ ]; }
+          if ((elements = from.getElementsByClassName(unescapeIdentifier(token))).length === 0) { return [ ]; }
             selector = selector.slice(0, lastPosition) + selector.slice(lastPosition).replace('.' + token,
               reOptimizeSelector.test(selector.charAt(selector.indexOf(token) - 1)) ? '' : '*');
         }

--- a/test/W3C-Selector-tests/W3C-Selector-tests-github.html
+++ b/test/W3C-Selector-tests/W3C-Selector-tests-github.html
@@ -597,6 +597,9 @@
 			t( "Descendant escaped ID", "div #test\\.foo\\[5\\]bar", ["test.foo[5]bar"] );
 			t( "Child escaped ID", "form > #foo\\:bar", ["foo:bar"] );
 			t( "Child escaped ID", "form > #test\\.foo\\[5\\]bar", ["test.foo[5]bar"] );
+
+			t( "ID selector with escaped number", "#\\31 23", ["123"] );
+			t( "Descendant ID selector with escaped number", "div #\\31 23", ["123"] );
 	
 			t( "ID Selector, child ID present", "#form > #radio1", ["radio1"] ); // bug #267
 			t( "ID Selector, not an ancestor ID", "#form #first", [] );
@@ -1250,6 +1253,7 @@
 			<span id="utf8class2" class="台北"></span>
 			<span id="foo:bar" class="foo:bar"></span>
 			<span id="test.foo[5]bar" class="test.foo[5]bar"></span>
+			<span id="123"></span>
 			
 			<foo_bar id="foobar">test element</foo_bar>
 

--- a/test/W3C-Selector-tests/W3C-Selector-tests-nwmatcher.html
+++ b/test/W3C-Selector-tests/W3C-Selector-tests-nwmatcher.html
@@ -596,6 +596,7 @@
 			t( "Multiple ID selectors using UTF8", "#台北Táiběi, #台北", ["台北Táiběi","台北"] );
 			t( "Descendant ID selector using UTF8", "div #台北", ["台北"] );
 			t( "Child ID selector using UTF8", "form > #台北", ["台北"] );
+                                                    
 	
 			t( "Escaped ID", "#foo\\:bar", ["foo:bar"] );
 			t( "Escaped ID", "#test\\.foo\\[5\\]bar", ["test.foo[5]bar"] );
@@ -603,6 +604,11 @@
 			t( "Descendant escaped ID", "div #test\\.foo\\[5\\]bar", ["test.foo[5]bar"] );
 			t( "Child escaped ID", "form > #foo\\:bar", ["foo:bar"] );
 			t( "Child escaped ID", "form > #test\\.foo\\[5\\]bar", ["test.foo[5]bar"] );
+
+			t( "ID selector with escaped number", "#\\31 23", ["123"] );
+			t( "Descendant ID selector with escaped number", "div #\\31 23", ["123"] );
+			t( "Class selector with escaped number", ".\\31 23", ["numericclass"] );
+			t( "Descendant class selector with escaped number", "div .\\31 23", ["numericclass"] );
 	
 			t( "ID Selector, child ID present", "#form > #radio1", ["radio1"] ); // bug #267
 			t( "ID Selector, not an ancestor ID", "#form #first", [] );
@@ -1274,7 +1280,9 @@
 			<span id="utf8class2" class="台北"></span>
 			<span id="foo:bar" class="foo:bar"></span>
 			<span id="test.foo[5]bar" class="test.foo[5]bar"></span>
-			
+			<span id="123"></span>
+			<span id="numericclass" class="123"></span>
+
 			<foo_bar id="foobar">test element</foo_bar>
 
 		</form>


### PR DESCRIPTION
If you pass a number like ```123``` to CSS.escape it'll produce an encoding like ```\31 23```. That's with a shortened unicode escape terminated by a space. I've updated nwmatcher to support this.

I added tests to W3C-Selector-tests-nwmatcher.html and W3C-Selector-tests-github.html, are these the right places to test this sort of thing? Should I put tests elsewhere as well?

I've only updated nwmatcher.js, I'm not sure how/if I should apply the changes to nwmatcher-base.js and nwmatcher-noqsa.js and how to test them if I do.