### PR TITLE
Update license to SPDX format

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,7 @@
     "selector",
     "ender"
   ],
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://javascript.nwbox.com/NWMatcher/MIT-LICENSE"
-    }
-  ],
+  "license": "MIT",
   "author": {
     "name": "Diego Perini",
     "email": "diego.perini@gmail.com",


### PR DESCRIPTION
Update license to correct SPDX format for 'MIT'

Docs.
Yarn: https://yarnpkg.com/lang/en/docs/package-json/#toc-license
NPM: https://docs.npmjs.com/files/package.json#license
SPDX: https://spdx.org/licenses/MIT.html