### PR TITLE
Fix matching non-HTML elements in HTML documents

### DIFF
--- a/src/nwmatcher-base.js
+++ b/src/nwmatcher-base.js
@@ -477,9 +477,10 @@
         }
 
         else if ((match = selector.match(Patterns.tagName))) {
-          source = 'if(e.nodeName' + (XML_DOCUMENT ?
-            '=="' + match[1] + '"' : TO_UPPER_CASE +
-            '=="' + match[1].toUpperCase() + '"') +
+          source = 'if(e.localName=="' + match[1] + '"' + (XML_DOCUMENT ?
+            '' :
+            '||e.namespaceURI="http://www.w3.org/1999/xhtml"&&' +
+              'e.localName.toLowerCase()=="' + match[1].toLowerCase() + '"') +
             '){' + source + '}';
         }
 

--- a/src/nwmatcher-noqsa.js
+++ b/src/nwmatcher-noqsa.js
@@ -527,9 +527,10 @@
         }
 
         else if ((match = selector.match(Patterns.tagName))) {
-          source = 'if(e.nodeName' + (XML_DOCUMENT ?
-            '=="' + match[1] + '"' : TO_UPPER_CASE +
-            '=="' + match[1].toUpperCase() + '"') +
+          source = 'if(e.localName=="' + match[1] + '"' + (XML_DOCUMENT ?
+            '' :
+            '||e.namespaceURI=="http://www.w3.org/1999/xhtml"&&' +
+              'e.localName.toLowerCase()=="' + match[1].toLowerCase() + '"') +
             '){' + source + '}';
         }
 

--- a/src/nwmatcher.js
+++ b/src/nwmatcher.js
@@ -1067,11 +1067,27 @@
         // *** Type selector
         // Foo Tag (case insensitive)
         else if ((match = selector.match(Patterns.tagName))) {
-          // both tagName and nodeName properties may be upper/lower case
-          // depending on their creation NAMESPACE in createElementNS()
-          source = 'if(e.nodeName' + (XML_DOCUMENT ?
-            '=="' + match[1] + '"' : '.toUpperCase()' +
-            '=="' + match[1].toUpperCase() + '"') +
+          // From the HTML Standard:
+          // > When comparing a CSS element type selector to the names of HTML
+          // > elements in HTML documents, the CSS element type selector must
+          // > first be converted to ASCII lowercase. The same selector when
+          // > compared to other elements must be compared according to its
+          // > original case. In both cases, the comparison is case-sensitive.
+
+          // For both HTML and XML documents, first check localName w/o any
+          // additional transformations. This will be the majority of
+          // successful cases. Next, if that fails and we are in an HTML
+          // document, check if a lower-cased version of the element's
+          // localName matches.
+
+          // We cannot use tagName (or its equivalent, nodeName), since that
+          // always returns the qualified name. And since localName can contain
+          // ":" characters, we cannot split tagName by ":" to get the
+          // upper-cased localName.
+          source = 'if(e.localName=="' + match[1] + '"' + (XML_DOCUMENT ?
+            '' :
+            '||e.namespaceURI="http://www.w3.org/1999/xhtml"&&' +
+              'e.localName.toLowerCase()=="' + match[1].toLowerCase() + '"') +
             '){' + source + '}';
         }
 

--- a/test/prototype/selector_test.html
+++ b/test/prototype/selector_test.html
@@ -110,6 +110,8 @@
       <span id="target_1"></span>
     </div>
   </div>
+
+  <svg id="icon"></svg>
 </div>
 
 </body>

--- a/test/prototype/tests/selector_test.js
+++ b/test/prototype/tests/selector_test.js
@@ -8,6 +8,7 @@ new Test.Unit.Runner({
   
   testSelectorWithTagName: function() {
     this.assertEnumEqual($A(document.getElementsByTagName('li')), $$('li'));
+    this.assertEnumEqual($A(document.getElementsByTagName('svg')), $$('svg'));
     this.assertEnumEqual([$('strong')], $$('strong'));
     this.assertEnumEqual([], $$('nonexistent'));
     


### PR DESCRIPTION
Refs: https://github.com/tmpvar/jsdom/issues/1986

Note, this does not fix https://github.com/tmpvar/jsdom/issues/1986#issuecomment-333231396, which will require more work on namespaces in general.